### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+plugins


### PR DESCRIPTION
We can ignore `build` and `plugins` as they are built when running create_repository.py.